### PR TITLE
Improvement to support DB using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 
 You can have separate databases for each NODE_ENV that you are using. Just a put a line in seed.json for each `NODE_ENV` that you are going to use. It defaults to `undefined`, `dev`, and `prod` but can be changed to whatever.
 
+### Database selection with DB_URI environment variable
+
+You can run seed passing a DB_URI environment to overrite the values in the seed.json, this allows extra flexibility.
+
 ## Contributing
 
 1. Clone project and run `npm install -g ./` from project root

--- a/lib/seed.js
+++ b/lib/seed.js
@@ -145,18 +145,18 @@ function getConnection() {
   return Q.promise(function(resolve, reject, notify) {
 
     var NODE_ENV = process.env.NODE_ENV;
-    var connectionString = null;
+    var DB_URI = process.env.DB_URI;
 
     // If NODE_ENV is set and there is no key in seed.json matching, throw an error
-    if(NODE_ENV && !config[NODE_ENV]) {
+    if(NODE_ENV && !config[NODE_ENV] && !DB_URI) {
       return reject('No key exists in seed.json for the passed in NODE_ENV');
     }
 
+    var connectionString = DB_URI || config[NODE_ENV];
+
     // If the connection string does not start with "mongodb://", add it
-    if(_.startsWith(config[NODE_ENV], "mongodb://")) {
-      connectionString = config[NODE_ENV];
-    } else {
-      connectionString = 'mongodb://' + config[NODE_ENV];
+    if(!_.startsWith(connectionString, "mongodb://")) {
+      connectionString = 'mongodb://' + connectionString;
     }
 
     mongo.connect(connectionString, function(err, db) {

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,18 @@ describe('run seed', function () {
 
   });
 
+  describe('with DB_URI', function() {
+    it('runs successfully with a seeds folder', function (done) {
+      child = exec('cd test/protocol; NODE_ENV=none DB_URI=mongodb://localhost/seeds node ../../bin/seed', function(err, stdout, stderr) {
+        expect(err).to.be.null;
+        // This is a cheap way to check that we did something
+        expect(stdout).to.match(/Seeding collection testing/);
+        expect(stdout).to.match(/All done. Go play!/);
+        done();
+      });
+    });
+  });
+
   describe('using MongoDB Extended JSON format', function() {
 
     it('tests $date format', function (done) {


### PR DESCRIPTION
While using in different environments it useful to be able to select the database using environment variable instead of a hardcoded one in seed.json

This PR allows to overwrite the connection string using DB_URI env var.