### PR TITLE
If NODE_ENV specified, JSON files will be searched in sub directories…

### DIFF
--- a/lib/seed.js
+++ b/lib/seed.js
@@ -9,15 +9,16 @@
  * @author Tom Caflisch
  */
 
-var Q       = require('q');
-var mongo   = require('mongodb').MongoClient;
-var config  = require(process.cwd() + "/seed.json");
-var dir     = process.cwd()+'/seeds';
-var fs      = require('fs'); // Used to get all the files in a directory
-var util    = require('util');
-var _       = require('lodash');
-var errno   = require('errno');
-var path    = require('path');
+var NODE_ENV = process.env.NODE_ENV;
+var Q        = require('q');
+var mongo    = require('mongodb').MongoClient;
+var config   = require(process.cwd() + "/seed.json");
+var dir      = process.cwd() + '/seeds' + (NODE_ENV ? '/' + NODE_ENV : '');
+var fs       = require('fs'); // Used to get all the files in a directory
+var util     = require('util');
+var _        = require('lodash');
+var errno    = require('errno');
+var path     = require('path');
 var json2mongo = require('json2mongo');
 
 /**
@@ -144,7 +145,6 @@ function getConnection() {
 
   return Q.promise(function(resolve, reject, notify) {
 
-    var NODE_ENV = process.env.NODE_ENV;
     var connectionString = null;
 
     // If NODE_ENV is set and there is no key in seed.json matching, throw an error


### PR DESCRIPTION
Hi Tom,

i have created a small pull request. Based on NODE_ENV the tool will only process the JSON files in a subdirectory below `/seeds`.

So, if you have defined as NODE_ENV:

* undefined => JSON files processed in `/seeds`
* dev => JSON files processed in `/seeds/dev`
* prod => JSON files processed in `/seeds/prod`

I think this could be relevant because on production, you probable want to import different JSON files than on development, and so on...

Please have a look, and maybe I see it coming by in a next release :-)

Regards,

Bart