### PR TITLE
Update version of json2mongo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "errno": "^0.1.4",
-    "json2mongo": "^1.1.0",
+    "json2mongo": "^2.0.0",
     "lodash": "^3.1.0",
     "mongodb": "~2.2.23",
     "optimist": "^0.6.1",


### PR DESCRIPTION
Currently it uses version of `json2mongo`: `1.1.0`.
But I've add some crucial changes to `json2mongo` to support `Decimal` values.
These changes are available only in `2.0.0` version so I believe it should be updated.
We really need these changes to be present in your package.

Thx.